### PR TITLE
Specify a PipedriveEmailType and PipedrivePhonenumberType

### DIFF
--- a/pipedrive/models.py
+++ b/pipedrive/models.py
@@ -5,7 +5,7 @@ from schematics.types import (
 )
 from schematics.types.compound import ListType, ModelType, DictType
 from types import (
-    PipedriveDateTime, PipedriveModelType, PipedriveDate, PipedriveTime
+    PipedriveDateTime, PipedriveModelType, PipedriveDate, PipedriveTime, PipedriveEmailType, PipedrivePhonenumberType
 )
 
 
@@ -125,8 +125,8 @@ class Person(Model):
     name = StringType(required=True)
     owner_id = PipedriveModelType(User, required=False)
     org_id = PipedriveModelType(Organization, required=False)
-    email = ListType(DictType(StringType), required=False)
-    phone = ListType(DictType(StringType), required=False)
+    email = PipedriveEmailType(required=False)
+    phone = PipedrivePhonenumberType(required=False)
     visible_to = IntType(required=False)
     add_time = PipedriveDateTime(required=False)
 

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -90,6 +90,9 @@ class PipedriveModelType(BaseType):
 
 class PipedriveListDictStringOrStringType(BaseType):
     """
+    Can be used as a base class for fields that receive different formats (list with dicts with strings or just
+    a string) from the Pipedrive API.
+
     Pipedrive inconsistently returns values for some fields, for example: "find" for a Person just returns a string
     for email even if there are multiple emails associated with that Person. "detail" for a Person returns a list
     containing a dict containing strings for emails. Because of this inconsistency we need to have a field that can
@@ -116,14 +119,20 @@ class PipedriveListDictStringOrStringType(BaseType):
 
 class PipedriveEmailType(PipedriveListDictStringOrStringType):
     """
-    We're just using these because the names don't suck as much.
+    Use this field type for models that can have multiple email addresses associated with them, such as Persons.
+    We're just using these, because they're more clear than the parent's name.
+
+    For more information see the parent's docstring.
     """
     pass
 
 
 class PipedrivePhonenumberType(PipedriveListDictStringOrStringType):
     """
-    We're just using these because the names don't suck as much.
+    Use this field type for models that can have multiple phone numbers associated with them, such as Persons.
+    We're just using these, because they're more clear than the parent's name.
+
+    For more information see the parent's docstring.
     """
     pass
 

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -74,7 +74,7 @@ class PipedriveModelType(BaseType):
         if isinstance(value, dict):
             return dict_to_model(value, self.model_class)
 
-        raise ConversionError(self.messages['value_type'] % self.model_class)            
+        raise ConversionError(self.messages['value_type'] % self.model_class)
 
     def to_primitive(self, value, context=None):
         if isinstance(value, self.model_class):
@@ -84,3 +84,37 @@ class PipedriveModelType(BaseType):
             return value['id']
 
         return value
+
+
+class PipedriveListDictStringOrStringType(BaseType):
+    """
+    Pipedrive inconsistently returns values for some fields, for example: "find" for a Person just returns a string
+    for email even if there are multiple emails associated with that Person. "detail" for a Person returns a list
+    containing a dict containing strings for emails. Because of this inconsistency we need to have a field that can
+    return the correct values even if the way they are represented changes. We are opting for the list-dict-string
+    because this allows us to better control these multiple values (email addresses, phone numbers etc.).
+    """
+    def to_native(self, value, context=None):
+        if isinstance(value, list):
+            return value
+        elif isinstance(value, basestring):
+            return [{'value': value}]
+
+    def to_primitive(self, value, context=None):
+        if isinstance(value, basestring):
+            value = [{'value': value}]
+        return value
+
+
+class PipedriveEmailType(PipedriveListDictStringOrStringType):
+    """
+    We're just using these because the names don't suck as much.
+    """
+    pass
+
+
+class PipedrivePhonenumberType(PipedriveListDictStringOrStringType):
+    """
+    We're just using these because the names don't suck as much.
+    """
+    pass

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -99,7 +99,7 @@ class PipedriveListDictStringOrStringType(BaseType):
     def to_native(self, value, context=None):
         if isinstance(value, list):
             return value
-        elif isinstance(value, basestring):
+        elif is_string(value):
             return [{'value': value}]
 
     def to_primitive(self, value, context=None):
@@ -108,7 +108,7 @@ class PipedriveListDictStringOrStringType(BaseType):
         # So when you, for example, get a person with multiple email addresses and try to update his name Pipedrive
         # will screw up his email addresses. In that case it's just better to update manually or specify None for
         # the email addresses (which means it won't update them at all).
-        if not isinstance(value, basestring) and isinstance(value, Iterable):
+        if not is_string(value) and isinstance(value, Iterable):
             raise ValueError("Pipedrive can't handle iterable objects. You can either specify one value of type base"
                              "string which will update the first record, or specify None which won't update anything")
         return value
@@ -126,3 +126,13 @@ class PipedrivePhonenumberType(PipedriveListDictStringOrStringType):
     We're just using these because the names don't suck as much.
     """
     pass
+
+
+def is_string(value):
+    """
+    Check if value is a string. Python 2 and 3 compatible.
+    """
+    try:
+        return isinstance(value, basestring)
+    except NameError:
+        return isinstance(value, str)


### PR DESCRIPTION
Pipedrive is inconsistent with the values it returns for email addresses and phone numbers. It can return both `string` types and `list`s containing `dict`s containing `string`s. We've now made a `PipedriveListDictStringOrStringType` field we can use for these return values. Ugly? Yes. Effective? Yes. We inherent from this field so we have more logical names for the fields we want to use (being `PipedriveEmailType` and `PipedrivePhonenumberType`).

We also don't allow for non-basestring iterables when creating or updating a Person, because Pipedrive can't handle these and will without warning mess up any of your email addresses or phonenumbers. You can either specify these fields to None if you don't want them updated or specify one value which will update just the first field. _Yes_ it _is_ weird that Pipedrive returns lists/dicts etc. but then consequently isn't able to update them, but we can't do anything about that unfortunately, except warn the user.
